### PR TITLE
use flattenObject on therapyRecommendation

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -1198,14 +1198,16 @@ export class PatientViewPageStore {
     }
 
     therapyRecommendationOnDelete = (therapyRecommendationToDelete: ITherapyRecommendation) => {
-        this._therapyRecommendations = this._therapyRecommendations.filter((therapyRecommendation:ITherapyRecommendation) => therapyRecommendationToDelete.id !== therapyRecommendation.id);
+        let therapyRecommendationToDeleteFlattened = flattenObject(therapyRecommendationToDelete);
+        this._therapyRecommendations = this._therapyRecommendations.filter((therapyRecommendation:ITherapyRecommendation) => therapyRecommendationToDeleteFlattened.id !== therapyRecommendation.id);
         this.writeTherapyRecommendations();
         return true;
     }
 
     therapyRecommendationOnAddOrEdit = (therapyRecommendationToAdd: ITherapyRecommendation) => {
-        this._therapyRecommendations = this._therapyRecommendations.filter((therapyRecommendation:ITherapyRecommendation) => therapyRecommendationToAdd.id !== therapyRecommendation.id);
-        this._therapyRecommendations.push(therapyRecommendationToAdd);
+        let therapyRecommendationToAddFlattened = flattenObject(therapyRecommendationToAdd);
+        this._therapyRecommendations = this._therapyRecommendations.filter((therapyRecommendation:ITherapyRecommendation) => therapyRecommendationToAddFlattened.id !== therapyRecommendation.id);
+        this._therapyRecommendations.push(therapyRecommendationToAddFlattened);
         let x = this.writeTherapyRecommendations();
         return true;
     }
@@ -1244,7 +1246,7 @@ export class PatientViewPageStore {
                 geneticCounselingRecommended: this.geneticCounselingRecommended,
                 rebiopsyRecommended: this.rebiopsyRecommended,
                 comment: this.commentRecommendation,
-                therapyRecommendations: flattenArray(this._therapyRecommendations)
+                therapyRecommendations: this._therapyRecommendations
             })))
         .end((err, res)=>{
             if (!err && res.ok) {
@@ -1260,7 +1262,7 @@ export class PatientViewPageStore {
                         geneticCounselingRecommended: this.geneticCounselingRecommended,
                         rebiopsyRecommended: this.rebiopsyRecommended,
                         comment: this.commentRecommendation,
-                        therapyRecommendations: flattenArray(this._therapyRecommendations)
+                        therapyRecommendations: this._therapyRecommendations
                     })))
                 .end((err, res)=>{
                     if (!err && res.ok) {

--- a/src/shared/api/TherapyRecommendationAPI.ts
+++ b/src/shared/api/TherapyRecommendationAPI.ts
@@ -61,7 +61,7 @@ export async function writeTherapyRecommendation(id:string, recommendation: IRec
             geneticCounselingRecommendation: recommendation.geneticCounselingRecommendation,
             rebiopsyRecommendation: recommendation.rebiopsyRecommendation,
             generalRecommendation: recommendation.generalRecommendation,
-            therapyRecommendations: flattenArray(recommendation.therapyRecommendations)
+            therapyRecommendations: recommendation.therapyRecommendations
         })))
     .end((err, res)=>{
         if (!err && res.ok) {
@@ -76,7 +76,7 @@ export async function writeTherapyRecommendation(id:string, recommendation: IRec
                     geneticCounselingRecommendation: recommendation.geneticCounselingRecommendation,
                     rebiopsyRecommendation: recommendation.rebiopsyRecommendation,
                     generalRecommendation: recommendation.generalRecommendation,
-                    therapyRecommendations: flattenArray(recommendation.therapyRecommendations)
+                    therapyRecommendations: recommendation.therapyRecommendations
                 })))
             .end((err, res)=>{
                 if (!err && res.ok) {


### PR DESCRIPTION
This changes the `therapyRecommendations` object to an array, instead of cascaded objects. Main benefit is that this allows data-binding using packages like jackson.

Comparing old and new schema:

**Old:**
```
{
  "comment": "",
  "geneticCounselingRecommended": false,
  "id": "",
  "rebiopsyRecommended": false,
  "therapyRecommendations": {
    "0": {
      "comment": [
        ""
      ],
      "evidenceLevel": "",
      "id": "",
      "modifications": [
        {
          "modified": "",
          "recommender": {
            "credentials": ""
          },
          "timestamp": ""
        }
      ],
      "reasoning": {
        "geneticAlterations": [
          {
            "hugoSymbol": "",
            "entrezGeneId": 0,
            "proteinChange": ""
          }
        ]
      },
      "references": [
        {
          "pmid": 0,
          "name": ""
        }
      ],
      "treatments": [
        {
          "name": "",
          "ncit_code": "",
          "synonyms": ""
        }
      ]
    }
  }
}
```
**New:**
```
{
  "comment": "",
  "geneticCounselingRecommended": false,
  "id": "",
  "rebiopsyRecommended": false,
  "therapyRecommendations": [
    {
      "comment": [
        ""
      ],
      "evidenceLevel": "",
      "id": "",
      "modifications": [
        {
          "modified": "",
          "recommender": {
            "credentials": ""
          },
          "timestamp": ""
        }
      ],
      "reasoning": {
        "geneticAlterations": [
          {
            "hugoSymbol": "",
            "entrezGeneId": 0,
            "proteinChange": ""
          }
        ]
      },
      "references": [
        {
          "pmid": 0,
          "name": ""
        }
      ],
      "treatments": [
        {
          "name": "",
          "ncit_code": "",
          "synonyms": ""
        }
      ]
    }
  ]
}
```