### PR TITLE
Add support for custom endpoint of json store

### DIFF
--- a/env/custom.sh
+++ b/env/custom.sh
@@ -1,2 +1,4 @@
 # set e.g.
 # export CBIOPORTAL_URL="http://localhost:8080"
+# export FHIRSPARK_HOST=localhost
+# export FHIRSPARK_PORT=3001

--- a/src/config/IAppConfig.ts
+++ b/src/config/IAppConfig.ts
@@ -5,6 +5,7 @@ export interface IAppConfig {
     frontendUrl?: string;
     serverConfig: IServerConfig;
     hide_login?: boolean;
+    fhirspark?: IFhirsparkConfig;
 }
 
 export type CategorizedConfigItems = {
@@ -118,3 +119,8 @@ export interface IServerConfig {
     dat_method: string;
     skin_show_gsva:boolean;
 }
+
+export interface IFhirsparkConfig {
+    host: string | null;
+    port: string | null;
+} 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -98,6 +98,11 @@ export function setServerConfig(serverConfig:{[key:string]:any }){
         config.apiRoot = `${frontendOverride.apiRoot}`;
     }
 
+    if (frontendOverride.fhirspark) {
+        console.log(`Overriding fhirspark with: `, frontendOverride.fhirspark);
+        config.fhirspark = frontendOverride.fhirspark;
+    }
+
     // allow any hardcoded serverConfig props to override those from service
     const mergedConfig = Object.assign({}, serverConfig, frontendOverride , config.serverConfig || {});
 
@@ -194,6 +199,13 @@ export function initializeConfiguration() {
     const frontendUrl = config.frontendUrl || `//${win.location.host}/`;
 
     const configServiceUrl = config.configurationServiceUrl || `${APIROOT}config_service.jsp`;
+
+    config.fhirspark = {};
+    // @ts-ignore: ENV_* are defined in webpack.config.js
+    config.fhirspark.host = `${ENV_FHIRSPARK_HOST || config.fhirspark.host}`;
+
+    // @ts-ignore: ENV_* are defined in webpack.config.js
+    config.fhirspark.port = `${ENV_FHIRSPARK_PORT || config.fhirspark.port}`;
 
     // should override both when in dev mode and when serving compiled source
     // code outside of legacy project

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -1211,8 +1211,13 @@ export class PatientViewPageStore {
     }
 
     private getJsonStoreUrl() {
-        // @ts-ignore: ENV_* are defined in webpack.config.js
-        return (`${ENV_FHIRSPARK_BASE}` || 'http://' + window.location.hostname + ':3001/patients') + '/';
+        let host = window.location.hostname;
+        let port = '3001';
+        if (AppConfig.fhirspark && AppConfig.fhirspark.host && AppConfig.fhirspark.host !== 'undefined')
+            host = AppConfig.fhirspark.host;
+        if (AppConfig.fhirspark && AppConfig.fhirspark.port && AppConfig.fhirspark.port !== 'undefined')
+        port = AppConfig.fhirspark.port;
+            return 'http://' + host + ':' + port + '/patients/';
     }
 
     private loadTherapyRecommendations() {

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -1211,7 +1211,8 @@ export class PatientViewPageStore {
     }
 
     private getJsonStoreUrl() {
-        return 'http://' + window.location.hostname + ':3001/patients/';
+        // @ts-ignore: ENV_* are defined in webpack.config.js
+        return (`${ENV_FHIRSPARK_BASE}` || 'http://' + window.location.hostname + ':3001/patients') + '/';
     }
 
     private loadTherapyRecommendations() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -145,6 +145,7 @@ var config = {
             'IS_DEV_MODE': isDev,
             'ENV_CBIOPORTAL_URL': process.env.CBIOPORTAL_URL? JSON.stringify(cleanAndValidateUrl(process.env.CBIOPORTAL_URL)) : '"replace_me_env_cbioportal_url"',
             'ENV_GENOME_NEXUS_URL': process.env.GENOME_NEXUS_URL? JSON.stringify(cleanAndValidateUrl(process.env.GENOME_NEXUS_URL)) : '"replace_me_env_genome_nexus_url"',
+            'ENV_FHIRSPARK_BASE': JSON.stringify(process.env.FHIRSPARK_BASE)
         }),
         new HtmlWebpackPlugin({cache: false, template: 'my-index.ejs'}),
         WebpackFailPlugin,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -145,7 +145,8 @@ var config = {
             'IS_DEV_MODE': isDev,
             'ENV_CBIOPORTAL_URL': process.env.CBIOPORTAL_URL? JSON.stringify(cleanAndValidateUrl(process.env.CBIOPORTAL_URL)) : '"replace_me_env_cbioportal_url"',
             'ENV_GENOME_NEXUS_URL': process.env.GENOME_NEXUS_URL? JSON.stringify(cleanAndValidateUrl(process.env.GENOME_NEXUS_URL)) : '"replace_me_env_genome_nexus_url"',
-            'ENV_FHIRSPARK_BASE': JSON.stringify(process.env.FHIRSPARK_BASE)
+            'ENV_FHIRSPARK_HOST': JSON.stringify(process.env.FHIRSPARK_HOST),
+            'ENV_FHIRSPARK_PORT': JSON.stringify(process.env.FHIRSPARK_PORT),
         }),
         new HtmlWebpackPlugin({cache: false, template: 'my-index.ejs'}),
         WebpackFailPlugin,


### PR DESCRIPTION
This allows setting a custom base for the json endpoint e.g. in `env/custom.sh` as we can't ensure that in the docker setup later on port 3001 will be available.